### PR TITLE
Lightcurve resample functions

### DIFF
--- a/utils/analysis.py
+++ b/utils/analysis.py
@@ -326,7 +326,7 @@ def submit_slurm_job(job_path, delete=False):
     
     submission_cmd = f'sbatch {job_path}'
     subp = subprocess.run(submission_cmd, shell=True, capture_output=True)
-    tims.sleep(0.1)
+    time.sleep(0.1)
     
     if delete:
         os.remove(job_path)

--- a/utils/analysis.py
+++ b/utils/analysis.py
@@ -15,7 +15,7 @@ from functools import wraps
 
 from nmma.em import analysis
 
-from utils.misc import strtime, suppress_print
+from misc import strtime, suppress_print
 
 
 def lightcurve_analysis(lightcurve_path, model, prior, outdir, label, tmax=None, slurm=False, **kwargs):
@@ -340,8 +340,14 @@ def get_trigger_time(lightcurve_path):
     
     Returns:
     - trigger_time (float): trigger time of lightcurve
+    
+    TODO:
+    - make it so it checks all filters and returns the earliest trigger time
     '''
     lightcurve_df = pd.read_json(lightcurve_path)
     lc_keys = list(lightcurve_df.keys())
-    trigger_time = lightcurve_df[lc_keys[0]][0][0]
+    trigger_time = np.inf
+    for key in lc_keys:
+        trigger_time = lightcurve_df[key][0][0] if lightcurve_df[key][0][0] < trigger_time else trigger_time
+    # trigger_time = lightcurve_df[lc_keys[0]][0][0]
     return trigger_time

--- a/utils/lightcurves.py
+++ b/utils/lightcurves.py
@@ -169,7 +169,7 @@ def validate_lightcurve(lightcurve_path, min_detections=3, min_time=3.1, all_ban
     if all_bands: ## check if all bands meet requirements
         all_bands_meet_criteria = True ## default to true, then check if any band does not meet criteria
 
-        for band in lightcurve_df.columns[1:]:
+        for band in lightcurve_df.columns[2:]:
             min_time_interval = lightcurve_df[(lightcurve_df['sample_times'] >= start_time) & (lightcurve_df['sample_times'] <= end_time)]
             num_detections = min_time_interval[band].apply(lambda val: 1 if val != np.inf and not np.isnan(val) else 0)
             meets_min_detections = num_detections.sum() >= min_detections
@@ -179,7 +179,7 @@ def validate_lightcurve(lightcurve_path, min_detections=3, min_time=3.1, all_ban
         return all_bands_meet_criteria
 
     else: ## ensure at least one band meets requirements
-        for band in lightcurve_df.columns[1:]:
+        for band in lightcurve_df.columns[2:]:
             min_time_interval = lightcurve_df[(lightcurve_df['sample_times'] >= start_time) & (lightcurve_df['sample_times'] <= end_time)]
             num_detections = min_time_interval[band].apply(lambda val: 1 if val != np.inf and not np.isnan(val) else 0)
             meets_min_detections = num_detections.sum() >= min_detections
@@ -189,9 +189,9 @@ def validate_lightcurve(lightcurve_path, min_detections=3, min_time=3.1, all_ban
 
         return False  # None of the bands meet the criteria
  
-    
-# known_bad = 'injections/lc_TrPi2018_00000.json'
-# print(validate_lightcurve(known_bad, min_detections=3, min_time=3.1, all_bands=False))
-# known_good = 'injections/lc_Me2017_00000.json'
-# print(validate_lightcurve(known_good, min_detections=3, min_time=3.1, all_bands=False))
+
+# def starting_lightcurve(full_lightcurve, output_dir, starting_sample=3)    
+
+
+# def observe_lightcurve(full_lightcurve,previous_lightcurve=None,)
     

--- a/utils/lightcurves.py
+++ b/utils/lightcurves.py
@@ -5,6 +5,7 @@ creates lightcurves from a given injection file using nmma
 import numpy as np
 import os 
 import pandas as pd
+pd.options.mode.chained_assignment = None
 import json 
 
 from astropy.time import Time
@@ -14,6 +15,8 @@ from argparse import Namespace
 from functools import reduce
 
 from nmma.em import create_lightcurves
+
+from analysis import get_trigger_time
 
 def generate_lightcurve(model, injection_path, outDir=None, lightcurve_label=None, filters=['ztfg'], **kwargs):
     '''
@@ -190,16 +193,57 @@ def validate_lightcurve(lightcurve_path, min_detections=3, min_time=3.1, all_ban
 
         return False  # None of the bands meet the criteria
  
+def get_filter_df(lightcurve_df, filter):
+    '''
+    Retreives a dataframe containing only the filter specified. Assumes structure of the read_lightcurve function.
+    
+    Args:
+    - lightcurve_df (pd.DataFrame): dataframe of lightcurve with associated times
+    - filter (str): filter to retreive
+    
+    Returns:
+    - filter_df (pd.DataFrame): dataframe of lightcurve with associated times for the specified filter
+    '''
+    existing_filters = [col for col in lightcurve_df.columns if col not in ['sample_times'] and '_err' not in col]
+    assert filter in existing_filters, 'filter {} does not exist in lightcurve'.format(filter)
+    filter_df_list = []
+    for row in lightcurve_df.iterrows():
+        if row[1][filter] != np.inf and row[1][filter] != np.nan:
+            filter_df_list.append(row[1])
+    filter_df = pd.DataFrame(filter_df_list)
+    return filter_df
 
-def starting_lightcurve(full_lightcurve, output_dir, starting_time=2, starting_observations=None, **kwargs):
+def generate_lightcurve_dict(lightcurve_df):
+    '''
+    Generates dictionary in the format needed to dump to a json
+    
+    Args:
+    - lightcurve_df (pd.DataFrame): dataframe of lightcurve with associated times
+    
+    Returns:
+    - lightcurve_dict (dict): dictionary of lightcurve with associated times
+    '''
+    filters = [col for col in lightcurve_df.columns if col not in ['sample_times'] and '_err' not in col]
+    lightcurve_dict = {}
+    for filter in filters:
+        filter_df = get_filter_df(lightcurve_df, filter)
+        sample_times = filter_df['sample_times'].tolist()
+        filter_vals = filter_df[filter].tolist()
+        filter_errs = filter_df[f'{filter}_err'].tolist()
+        ## use sample times to itterate the above 3 lists. if they do not have the same length, then there is an issue
+        lightcurve_dict[filter] = [[sample_times[i], filter_vals[i], filter_errs[i]] for i in range(len(sample_times))]
+    return lightcurve_dict
+
+def starting_lightcurve(full_lightcurve, outdir, starting_time=2, starting_observations=None, correct_times=False, **kwargs):
         '''
         Retreives a full lightcurve from a lightcurve file and generates a new file with enough observations to start the multi-arm bandit analysis. This is either the first n observations, where n is starting_observations, or the first observations within a certain number of days from the first observation. I would recommend using starting_observations when using ztf sampling and then use starting_time for even/better sampling. If the starting time does not contain at least 2 points, will print a warning and then default to setting starting_observations to 2 even if it's not provided.
         
         Args:
         - full_lightcurve (str): path to full lightcurve file
-        - output_dir (str): output directory for starting lightcurve file
+        - outdir (str): output directory for starting lightcurve file
         - starting_time (float): time interval from the start of the lightcurve that needs to contain the minimum number of detections (default=2)
         - starting_observations (int): number of observations to start with (default=None). You only need to provide the starting_time or starting_observations, but starting_observations will supercede starting_time if both are provided.
+        - correct_times (bool): whether or not to correct the times so that the first observation is at the same time as the original lightcurve (default=False)
         
         Returns:
         - starting_lightcurve (str): path to starting lightcurve file
@@ -208,7 +252,6 @@ def starting_lightcurve(full_lightcurve, output_dir, starting_time=2, starting_o
         - make it so it checks about non-detections
         '''
         full_lightcurve_df = read_lightcurve(full_lightcurve, **kwargs)
-        start_time = full_lightcurve_df['sample_times'].min()
         filters = [col for col in full_lightcurve_df.columns if col not in ['sample_times'] and '_err' not in col]
         if starting_time and starting_observations is None:
             starting_lightcurve_df = full_lightcurve_df[full_lightcurve_df['sample_times'] <= starting_time]
@@ -219,32 +262,58 @@ def starting_lightcurve(full_lightcurve, output_dir, starting_time=2, starting_o
             ## get the first n observations, where n is starting_observations for each filter
             starting_lightcurve = []
             for filter in filters:
-                filter_df_list = []
-                for row in full_lightcurve_df.iterrows():
-                    if row[1][filter] != np.inf and row[1][filter] != np.nan:
-                        filter_df_list.append(row[1])
-                filter_df = pd.DataFrame(filter_df_list)
+                filter_df = get_filter_df(full_lightcurve_df, filter)
                 starting_lightcurve.append(filter_df.iloc[:starting_observations])
             starting_lightcurve_df = pd.concat(starting_lightcurve)
-        starting_lightcurve_path = os.path.join(output_dir, os.path.basename(full_lightcurve))
-        os.makedirs(output_dir, exist_ok=True)
+        if correct_times:
+            tmin = get_trigger_time(full_lightcurve)
+            starting_lightcurve_df.loc[:,'sample_times'] += tmin
         ## construct dictionary to write to json. Each key is the filter, and the value for each key is a list of lists, with the sublists containing three terms: sample_times, filter, and filter_err for each observation
-        starting_lightcurve_dict = {}
-        for filter in filters:
-            filter_df_list = []
-            for row in starting_lightcurve_df.iterrows():
-                if row[1][filter] != np.inf and row[1][filter] != np.nan:
-                    filter_df_list.append(row[1])
-            filter_df = pd.DataFrame(filter_df_list)
-            sample_times = filter_df['sample_times'].tolist()
-            filter_vals = filter_df[filter].tolist()
-            filter_errs = filter_df[f'{filter}_err'].tolist()
-            ## use sample times to itterate the above 3 lists. if they do not have the same length, then there is an issue
-            starting_lightcurve_dict[filter] = [[sample_times[i], filter_vals[i], filter_errs[i]] for i in range(len(sample_times))]
+        starting_lightcurve_dict = generate_lightcurve_dict(starting_lightcurve_df)
+        starting_lightcurve_path = os.path.join(outdir, kwargs.get('lightcurve_label', os.path.basename(full_lightcurve)))
+        os.makedirs(outdir, exist_ok=True)
         with open(starting_lightcurve_path, 'w') as f:
             json.dump(starting_lightcurve_dict, f, indent=4)
         return starting_lightcurve_path
 
 
-
+def observe_lightcurve(full_lightcurve, previous_lightcurve, outdir, step_size=1,filters=['ztfg'],**kwargs):
+    '''
+    Takes in a full lightcurve and a previous lightcurve, and returns a new lightcurve with the next step_size observations. This is useful for simulating observing a lightcurve in real time. 
     
+    Args:
+    - full_lightcurve (str): path to full lightcurve file
+    - previous_lightcurve (str): path to previous lightcurve file
+    - step_size (int): interval on which to add observations (default=1). For the default, this will add any observations made in the next day.
+    - filters (list): list of filters to observe (default=['ztfg']). These filters need to exist
+    - outdir (str): output directory for next lightcurve file
+    
+    Returns:
+    - next_lightcurve (str): path to next lightcurve file
+    
+    TODO:
+    - make it so it checks about non-detections
+    - make an option so you can specify that you want the next observation regardless of whether or not it's in the next step_size interval (maybe)
+    '''
+    full_lightcurve_df = read_lightcurve(full_lightcurve, **kwargs)
+    previous_lightcurve_df = read_lightcurve(previous_lightcurve, **kwargs)
+    start_time = full_lightcurve_df['sample_times'].min()
+    end_time = previous_lightcurve_df['sample_times'].max() + step_size ## end time is the interval from the start time we want to check for detections
+    new_observations = []
+    for filter in filters:
+        full_filter_df = get_filter_df(full_lightcurve_df, filter)
+        previous_filter_df = get_filter_df(previous_lightcurve_df, filter)
+        next_observations = full_filter_df[(full_filter_df['sample_times'] > previous_filter_df['sample_times'].max()) & (full_filter_df['sample_times'] <= end_time)]
+        new_observations.append(next_observations)
+    new_observations_df = pd.concat(new_observations)
+    next_lightcurve_df = pd.concat([previous_lightcurve_df, new_observations_df])
+    
+    next_lightcurve_dict = generate_lightcurve_dict(next_lightcurve_df)
+    next_lightcurve_path = os.path.join(outdir, kwargs.get('lightcurve_label', os.path.basename(full_lightcurve)))
+    os.makedirs(outdir, exist_ok=True)
+    with open(next_lightcurve_path, 'w') as f:
+        json.dump(next_lightcurve_dict, f, indent=4)
+    return next_lightcurve_path  
+    
+    
+starting_lightcurve(full_lightcurve='test/lc_Me2017_00000.json',outdir='test_starting',starting_time=2, starting_observations=None, correct_times=True)


### PR DESCRIPTION
Added two useful functions:
- starting_lightcurve: this takes a full lightcurve and outputs a json file with only the initial observations
- observe_lightcurve: this takes a full lightcurve and a partial lightcurve so one can generate a new json with any additional observations one wants to make.

Currently, there are two issues:
- [ ] In both functions, the option to use correct_times, which should change the times from the relative times to the actual times in the original file, does not align the times correctly. I believe it finds the time of the earliest observation rather than the time of the first data point, which I believe is what's causing the disparity in time sampling times when this flag is set. 
- [ ] observe_lightcurve, when finding the next lightcurve to observe, does not actually filter any intervening measurements between steps. In other words, it will just fill in any lightcurve observations after the last observation in the existing lightcurve and the specified timestep. This should be changed so one can specify the start and end time to pull new data from so we don't have that existing issue where it grabs all data.
